### PR TITLE
Feat@expanding impact estimation

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -172,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = da.estimate_highest_impact(\n",
+    "data = da.estimate_ltv_impact(\n",
     "    days_limit=60, \n",
     "    spending_breaks={\"No spend\": 0.0, 'Low spend': 10, 'Medium spend': 100, 'High spend': 99999},\n",
     "    population_increase={\"No spend\": 0.2, \"Low spend\": 0.1, \"High spend\": 0.05}, \n",

--- a/src/exploratory.py
+++ b/src/exploratory.py
@@ -482,14 +482,14 @@ class LTVexploratory:
         return fig, data
 
 
-    def estimate_highest_impact(
+    def estimate_ltv_impact(
             self,
             days_limit: int,
             spending_breaks: Dict[str, float],
             population_increase: Dict[str, float]
             ):
         """
-        Estimate an upper-bound of the impact of using a predicted LTV (pLTV) strategy for campaign optimization.
+        Estimate the impact of using a predicted LTV (pLTV) strategy for campaign optimization.
         The estimate is calculated by increasing the number of customers according to [population_increase] and their
         classification at a later moment [days_limit]. 
         The impact is calculated by seeing the increase in revenue at a late date [days limit] caused by this increase


### PR DESCRIPTION
Changing how the LTV Optimization is expected to impact.

# Before
The impact was calculating by assuming that the LTV of all users were going to be the same as the one considered as High Spenders. The problem with this is that depending on how one defines the High Spenders, it will cause a massive increase in revenue. It is unrealistic to assume that *all* users acquired by any marketing campaign, even if optimized for LTV, will be able to acquire only high spenders at no cost of reducing the number of spenders

# After
- Increase related to the number of *users*, not the LTV of them
- Increase is inputted by the user, thus making it clearer what the increase is
- Makes increase an argument, while this creates some friction of use as the user has to input themselves the assumption, it at least gives the possibility to test out multiple scenarios
- consider the classification of the customers at a late date when considering if they are low/mediunm/high/highest spenders

# Changes
- `LTVExploratory.estimate_highest_impact()`: changed the LTV estimated as defined above. Added 2 parameters as well: `early_limit` and `population_increase`
- renamed function to `estimate_ltv_impact()`, as we are no longer providing an upper-bound for the LTV optimization, but just giving the tool for one to estimate it based on their own assumption

# Further improvements
- Make an UI so that the user may interactively change the increase in the number of users
- also consider late revenue consideration