### PR TITLE
fix: error in plot days to first purchase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 
 # Ignore files related to API keys
 .env
+testenv
 
 # Ignore everything related to clients
 client_data/

--- a/src/exploratory.py
+++ b/src/exploratory.py
@@ -175,7 +175,8 @@ class LTVexploratory:
     - Total Events: {data_customers.shape[0]:,d} events.
     """
         )
-        data_events = self.joined_df[~self.joined_df[self.event_time_col].isnull()]
+        data_events = self.joined_df[~self.joined_df[self.event_time_col].isnull(
+        )]
         unique_event_types = data_events[self.event_name_col].nunique()
         event_list = list(data_events[self.event_name_col].unique())
 
@@ -473,6 +474,7 @@ class LTVexploratory:
         # numbers for the title
         data[self.uuid_col] = data[self.uuid_col] / data[self.uuid_col].sum()
         data = data[data[self.uuid_col].cumsum() < truncate_share]
+        data = data[data["dsi"] >= 0]
 
         share_customers_within_window = data[data["dsi"] <= optimization_window][
             self.uuid_col


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- remove negative value from data["dsi"] before the plot in plot_customers_histogram_per_conversion_day, exploratory.py
- need further investigation into root causes as below:

- 1st in general we should better understand the logic behind the “dsi” column, and prevent similar errors in the future. Dropping the negative value is just fixing the symptom without understanding the cause.

- 2nd, comparing to the dummy data that has 20k customers & 20k registration events, the real dataset has more registration date than IDs —> the reg. events are not unique. This is doesn’t make sense to me because the “registration event”, or the start date, should be unique —> The package should check for unique reg events and gives warning or even stops if not right.

- 3rd, the script with real data is adding the column “event_name” to customer_table, which is not necessary, but missing  “event_name” column in real data's event_table, which ISisnecessary. The package somehow still works even with the wrong specification, which is not right —> this should be fixed too.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[NOTEBOOK|SDK|DOCS|MISC] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message
-->

## Test Plan:

ran example.ipynb with real data until plot_customers_histogram_per_conversion_day without plot error 
